### PR TITLE
feat: use hook to define current year for licenses and copyright headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.DS_Store
+.atom/
+.idea/
+.vscode/
+
+# Files and directories created by pub
+.dart_tool/
+.packages
+pubspec.lock
+
+# Conventional directory for build outputs
+build/

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,2 @@
 analyzer:
-  exclude: [brick/**]
+  exclude: [brick/__brick__/**]

--- a/app/LICENSE
+++ b/app/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Very Good Ventures
+Copyright (c) 2022 Very Good Ventures
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/brick/hooks/pre_gen.dart
+++ b/brick/hooks/pre_gen.dart
@@ -1,0 +1,5 @@
+import 'package:mason/mason.dart';
+
+void run(HookContext context) {
+  context.vars['current_year'] = DateTime.now().year;
+}

--- a/brick/hooks/pubspec.yaml
+++ b/brick/hooks/pubspec.yaml
@@ -1,0 +1,7 @@
+name: very_good_core_hooks
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  mason: ^0.1.0-dev

--- a/tool/generator/main.dart
+++ b/tool/generator/main.dart
@@ -8,9 +8,9 @@ final _androidKotlinPath =
     path.join(_androidPath, 'app', 'src', 'main', 'kotlin');
 final _orgPath = path.join(_androidKotlinPath, 'com');
 final _staticDir = path.join('tool', 'generator', 'static');
-final year = DateTime.now().year;
+
 final copyrightHeader = '''
-// Copyright (c) $year, Very Good Ventures
+// Copyright (c) {{current_year}}, Very Good Ventures
 // https://verygood.ventures
 //
 // Use of this source code is governed by an MIT-style
@@ -66,6 +66,10 @@ void main() async {
                 path.isWithin(_androidPath, file.path)
                     ? '{{#dotCase}}{{org_name}}{{/dotCase}}.{{#snakeCase}}{{project_name}}{{/snakeCase}}'
                     : '{{#dotCase}}{{org_name}}{{/dotCase}}.{{#paramCase}}{{project_name}}{{/paramCase}}',
+              )
+              .replaceAll(
+                'Copyright (c) 2022 Very Good Ventures',
+                'Copyright (c) {{current_year}} Very Good Ventures',
               ),
         );
         final fileSegments = file.path.split('/').sublist(2);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Use mason hooks to set the copyright years to be generated upon brick usage, not creation. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
