### PR TITLE
feat: use flavor app name for the bundle name

### DIFF
--- a/brick/__brick__/{{project_name.snakeCase()}}/ios/Runner/Info.plist
+++ b/brick/__brick__/{{project_name.snakeCase()}}/ios/Runner/Info.plist
@@ -18,7 +18,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>{{project_name.titleCase()}}</string>
+	<string>$(FLAVOR_APP_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/tool/generator/main.dart
+++ b/tool/generator/main.dart
@@ -65,6 +65,14 @@ void main() async {
           file = await file.writeAsString('$copyrightHeader\n$contents');
         }
 
+        if (file.path.endsWith('Info.plist')) {
+          final contents = await file.readAsString();
+          file = await file.writeAsString(contents.replaceAll(
+            '<string>Very Good Core</string>',
+            r'<string>$(FLAVOR_APP_NAME)</string>',
+          ));
+        }
+
         final contents = await file.readAsString();
         file = await file.writeAsString(
           contents
@@ -78,6 +86,7 @@ void main() async {
                 'Copyright (c) {{current_year}} Very Good Ventures',
               ),
         );
+
         final fileSegments = file.path.split('/').sublist(2);
         if (fileSegments.contains('very_good_core')) {
           final newPathSegment = fileSegments.join('/').replaceAll(


### PR DESCRIPTION
## Description

Use FLAVOR_APP_NAME in CFBundleName so generated archives include the flavor for better identification of the different flavors on the project.

Output:
<img width="696" alt="Screenshot 2022-11-24 at 17 02 00" src="https://user-images.githubusercontent.com/835641/203857641-9b0954b3-f188-4564-b718-3c8df71dee92.png">

Foxes #204 


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
