### PR TITLE
docs: Translation generation in README.md (issue #259)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,13 @@ Update the `CFBundleLocalizations` array in the `Info.plist` at `ios/Runner/Info
     }
 }
 ```
+### Generating the translations
 
+In order to use the translations, you need to generate them. From the root folder of the app, run the following command:
+
+```
+flutter gen-l10n
+```
 [coverage_badge]: src/my_app/coverage_badge.svg
 [flutter_localizations_link]: https://api.flutter.dev/flutter/flutter_localizations/flutter_localizations-library.html
 [internationalization_link]: https://flutter.dev/docs/development/accessibility-and-localization/internationalization


### PR DESCRIPTION
<!--
Added documentation for running the l10n generation.
-->

## Description

At the end of the documentation for localization, I added instructions for running the generator.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
