### PR TITLE
fix(Android): change launchMode on Android to singleTask

### DIFF
--- a/src/my_app/android/app/src/main/AndroidManifest.xml
+++ b/src/my_app/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"


### PR DESCRIPTION


## Description
- We have discovered that launchMode=singleTop on Android opens a new instance of the app every time we open a deep-link on some devices. This change solves this problem by using launchMode=singleTask, which maintains a single instance of the app.

This closes #296 
<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
